### PR TITLE
Bugfix and Cidr Param Support

### DIFF
--- a/docs/Get-VLSMBreakdown.md
+++ b/docs/Get-VLSMBreakdown.md
@@ -13,7 +13,7 @@ This command is to calculate the network range breakdown to subnets, given the l
 ## SYNTAX
 
 ```
-Get-VLSMBreakdown [-Network] <IPNetwork> [-SubnetSize] <Array> [<CommonParameters>]
+Get-VLSMBreakdown [-Network] <IPNetwork> [-SubnetSize] <Array> [<CommonParameters>] [-SubnetSizeCidr] <Array> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -31,7 +31,23 @@ PS C:\> $subnets = @{type = "GTWSUBNET"; size = 30},
 PS C:\> Get-VLSMBreakdown -Network 10.10.5.0/24 -SubnetSize $subnets
 ```
 
-The variable $subnets contains subnets, or subnet zones we want to use. "Type" - specifies the name of the zone or subnet. "Size" - sets the maximum number of IPs which will be available for the subnet.
+The variable $subnets contains subnets, or subnet zones we want to use.
+- type: specifies the name of the zone or subnet.
+- size: sets the maximum number of IPs which will be available for the subnet.
+
+### Example 2
+```powershell
+PS C:\> $subnets = @{type = "GTWSUBNET"; cidr = 27},
+>> @{type = "DMZSUBNET"; cidr = 26},
+>> @{type = "EDGSUBNET"; cidr = 27},
+>> @{type = "APPSUBNET"; cidr = 26},
+>> @{type = "CRESUBNET"; cidr = 26}
+PS C:\> Get-VLSMBreakdown -Network 10.10.5.0/24 -SubnetSizeCidr $subnets
+```
+
+The variable $subnets contains subnets, or subnet zones we want to use. 
+- type: specifies the name of the zone or subnet. 
+- cidr: specifies the address range based on Cidr notation.
 
 ## PARAMETERS
 
@@ -52,6 +68,21 @@ Accept wildcard characters: False
 
 ### -SubnetSize
 The array of subnets in a form of a hashtable @{type = "<name>"; size = <int>} we want to put into the specified network range
+
+```yaml
+Type: Array
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SubnetSizeCidr
+The array of subnets in a form of network cidr notation @{type = "<name>"; cidr = <int>} we want to put into the specified network range
 
 ```yaml
 Type: Array

--- a/ipmgmt.psd1
+++ b/ipmgmt.psd1
@@ -8,117 +8,117 @@
 
 @{
 
-# Script module or binary module file associated with this manifest.
-RootModule = 'ipmgmt.psm1'
-
-# Version number of this module.
-ModuleVersion = '0.1.0'
-
-# Supported PSEditions
-# CompatiblePSEditions = @()
-
-# ID used to uniquely identify this module
-GUID = '77fd7e63-fda8-493e-bdcf-3668ae711a79'
-
-# Author of this module
-Author = 'Andrey Vernigora'
-
-# Company or vendor of this module
-CompanyName = 'NONE'
-
-# Copyright statement for this module
-Copyright = '(c) Andrey Vernigora. All rights reserved.'
-
-# Description of the functionality provided by this module
-Description = 'Powershell module to perform IP Range calculations'
-
-# Minimum version of the PowerShell engine required by this module
-# PowerShellVersion = ''
-
-# Name of the PowerShell host required by this module
-# PowerShellHostName = ''
-
-# Minimum version of the PowerShell host required by this module
-# PowerShellHostVersion = ''
-
-# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# DotNetFrameworkVersion = ''
-
-# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# CLRVersion = ''
-
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
-
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
-
-# Assemblies that must be loaded prior to importing this module
-RequiredAssemblies = @('.\bin\System.Net.IPNetwork.dll')
-
-# Script files (.ps1) that are run in the caller's environment prior to importing this module.
-# ScriptsToProcess = @()
-
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
-
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
-
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
-
-# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = '*'
-
-# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = '*'
-
-# Variables to export from this module
-VariablesToExport = '*'
-
-# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = '*'
-
-# DSC resources to export from this module
-# DscResourcesToExport = @()
-
-# List of all modules packaged with this module
-# ModuleList = @()
-
-# List of all files packaged with this module
-# FileList = @()
-
-# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-PrivateData = @{
-
-    PSData = @{
-
-        # Tags applied to this module. These help with module discovery in online galleries.
-        # Tags = @()
-
-        # A URL to the license for this module.
-        # LicenseUri = ''
-
-        # A URL to the main website for this project.
-        # ProjectUri = ''
-
-        # A URL to an icon representing this module.
-        # IconUri = ''
-
-        # ReleaseNotes of this module
-        # ReleaseNotes = ''
-
-    } # End of PSData hashtable
-
-} # End of PrivateData hashtable
-
-# HelpInfo URI of this module
-# HelpInfoURI = ''
-
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''
-
-}
-
-
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'ipmgmt.psm1'
+    
+    # Version number of this module.
+    ModuleVersion = '0.1.18'
+    
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
+    
+    # ID used to uniquely identify this module
+    GUID = '77fd7e63-fda8-493e-bdcf-3668ae711a79'
+    
+    # Author of this module
+    Author = 'Andrey Vernigora'
+    
+    # Company or vendor of this module
+    CompanyName = 'NONE'
+    
+    # Copyright statement for this module
+    Copyright = '(c) Andrey Vernigora. All rights reserved.'
+    
+    # Description of the functionality provided by this module
+    Description = 'Powershell module to perform IP Range calculations'
+    
+    # Minimum version of the PowerShell engine required by this module
+    # PowerShellVersion = ''
+    
+    # Name of the PowerShell host required by this module
+    # PowerShellHostName = ''
+    
+    # Minimum version of the PowerShell host required by this module
+    # PowerShellHostVersion = ''
+    
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
+    
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # CLRVersion = ''
+    
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
+    
+    # Modules that must be imported into the global environment prior to importing this module
+    # RequiredModules = @()
+    
+    # Assemblies that must be loaded prior to importing this module
+    RequiredAssemblies = @('.\bin\System.Net.IPNetwork.dll')
+    
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
+    
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
+    
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
+    
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
+    
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = '*'
+    
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = '*'
+    
+    # Variables to export from this module
+    VariablesToExport = '*'
+    
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = '*'
+    
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
+    
+    # List of all modules packaged with this module
+    # ModuleList = @()
+    
+    # List of all files packaged with this module
+    # FileList = @()
+    
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
+    
+        PSData = @{
+    
+            # Tags applied to this module. These help with module discovery in online galleries.
+            # Tags = @()
+    
+            # A URL to the license for this module.
+            # LicenseUri = ''
+    
+            # A URL to the main website for this project.
+            # ProjectUri = ''
+    
+            # A URL to an icon representing this module.
+            # IconUri = ''
+    
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
+    
+        } # End of PSData hashtable
+    
+    } # End of PrivateData hashtable
+    
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
+    
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
+    
+    }
+    
+    

--- a/networktools.ps1
+++ b/networktools.ps1
@@ -10,7 +10,6 @@ function Get-VLSMBreakdown {
         [array]$SubnetSize
     )
 
-
     function processRecord($net, $cidr, $type) {
         try {
             #try breaking down a network block by CIDR in a form of length
@@ -103,6 +102,11 @@ function Get-VLSMBreakdown {
             #pick a msk form a queue
             $v = $vlsmMasks.Dequeue()
             try {
+                #reordering the queue to keep longest masks up top
+                $t = [System.Collections.Queue]::new()
+                $vlsmStack.ToArray() | Sort-Object -Property CIDR -Descending | % { $t.Enqueue($_) }
+                $vlsmStack = $t
+                
                 #pick a network block form a queue
                 $current = $vlsmStack.Dequeue()
             }
@@ -178,7 +182,7 @@ function Get-IPRanges {
                 # skip the network if it is not in a base range
                 continue;
             }
-            else {Write-Verbose "$ns is in a $BaseNet"}
+            else { Write-Verbose "$ns is in a $BaseNet" }
 
             # test if 'next subnet' overlaps any of the existing below it in a sorted list
             $k = $i; $isoverlap = $false


### PR DESCRIPTION
I took the liberty to update your module, because I ran into an error as soon as I wanted to deploy only one subnet and this subnet had the same size as the VNET. In this case I did not get any output. 

In addition, I added a cidr support as I found that easier than having to have the "usable IPs" in my mind.

Changes are:
- Bugfix for VNET/Subnet of the same size
- Support for Cidr notation
- More error handling (error messages)
- Update of psd1
- Update of readme for "Get-VLSMBreakdown"

All changes concern only the subnet calculation "Get-VLSMBreakdown".

I would be happy if this fits for you and you would update it in the PsGallery.
If you have any questions, feel free to contact me!

Best
Daniel